### PR TITLE
Refactor/listar por pagina

### DIFF
--- a/src/main/java/com/template/business/services/MeteorologiaService.java
+++ b/src/main/java/com/template/business/services/MeteorologiaService.java
@@ -1,12 +1,13 @@
 package com.template.business.services;
 
+import com.template.data.DTOs.MeteorologiaDTOLista;
 import com.template.data.entity.MeteorologiaEntity;
 import com.template.data.repository.MeteorologiaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.List;
 
 @Service
 public class MeteorologiaService {
@@ -14,8 +15,8 @@ public class MeteorologiaService {
     @Autowired
     MeteorologiaRepository meteorologiaRepository;
 
-    public List<MeteorologiaEntity> listarTudo() {
-        return meteorologiaRepository.findAll();
+    public Page<MeteorologiaDTOLista> listarRegistros(Pageable paginacao) {
+        return meteorologiaRepository.findAll(paginacao).map(MeteorologiaDTOLista::new);
     }
 
     public MeteorologiaEntity novoRegistro(MeteorologiaEntity meteorologia) {

--- a/src/main/java/com/template/business/services/MeteorologiaService.java
+++ b/src/main/java/com/template/business/services/MeteorologiaService.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 public class MeteorologiaService {
@@ -17,6 +19,10 @@ public class MeteorologiaService {
 
     public Page<MeteorologiaDTOLista> listarRegistros(Pageable paginacao) {
         return meteorologiaRepository.findAll(paginacao).map(MeteorologiaDTOLista::new);
+    }
+
+    public List<MeteorologiaEntity> listarTudo() {
+        return meteorologiaRepository.findAll();
     }
 
     public MeteorologiaEntity novoRegistro(MeteorologiaEntity meteorologia) {

--- a/src/main/java/com/template/data/DTOs/MeteorologiaDTOLista.java
+++ b/src/main/java/com/template/data/DTOs/MeteorologiaDTOLista.java
@@ -1,0 +1,14 @@
+package com.template.data.DTOs;
+
+import com.template.data.entity.MeteorologiaEntity;
+
+import java.time.LocalDate;
+
+public record MeteorologiaDTOLista(
+        String cidade,
+        LocalDate data
+) {
+    public MeteorologiaDTOLista(MeteorologiaEntity meteorologia) {
+        this(meteorologia.getCidade(), meteorologia.getData());
+    }
+}

--- a/src/main/java/com/template/data/entity/MeteorologiaEntity.java
+++ b/src/main/java/com/template/data/entity/MeteorologiaEntity.java
@@ -3,11 +3,8 @@ package com.template.data.entity;
 import com.template.data.enumKind.Tempo;
 import com.template.data.enumKind.Turno;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Entity
 @Table(name = "meteorologia")
@@ -61,16 +58,10 @@ public class MeteorologiaEntity {
     public MeteorologiaEntity() {
     }
 
-    public MeteorologiaEntity(long l, String cidade2, Date date) {
-    }
-
     public long getId() {
         return id;
     }
 
-    public void setId(long id) {
-        this.id = id;
-    }
 
     public String getCidade() {
         return cidade;

--- a/src/main/java/com/template/data/repository/MeteorologiaRepository.java
+++ b/src/main/java/com/template/data/repository/MeteorologiaRepository.java
@@ -1,10 +1,15 @@
 package com.template.data.repository;
 
 import com.template.data.entity.MeteorologiaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MeteorologiaRepository extends JpaRepository<MeteorologiaEntity, Long> {
+
+    @Override
+    Page<MeteorologiaEntity> findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/template/data/repository/MeteorologiaRepository.java
+++ b/src/main/java/com/template/data/repository/MeteorologiaRepository.java
@@ -4,8 +4,6 @@ import com.template.data.entity.MeteorologiaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface MeteorologiaRepository extends JpaRepository<MeteorologiaEntity, Long> {
 

--- a/src/main/java/com/template/presentation/controller/MeteorologiaController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologiaController.java
@@ -13,6 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @CrossOrigin(origins = "http://localhost:4767")
 @RestController
 @RequestMapping("/api/v1/meteorologia")
@@ -25,6 +27,11 @@ public class MeteorologiaController {
     public ResponseEntity<Page<MeteorologiaDTOLista>> buscarRegistros(
             @PageableDefault(sort = {"data"}, direction = Sort.Direction.DESC) Pageable paginacao) {
         return ResponseEntity.ok(meteorologiaService.listarRegistros(paginacao));
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<MeteorologiaEntity>> buscarTudo() {
+        return ResponseEntity.ok(meteorologiaService.listarTudo());
     }
 
     @PostMapping

--- a/src/main/java/com/template/presentation/controller/MeteorologiaController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologiaController.java
@@ -1,13 +1,15 @@
 package com.template.presentation.controller;
 
 import com.template.business.services.MeteorologiaService;
+import com.template.data.DTOs.MeteorologiaDTOLista;
 import com.template.data.entity.MeteorologiaEntity;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:4767")
 @RestController
@@ -18,11 +20,12 @@ public class MeteorologiaController {
     MeteorologiaService meteorologiaService;
 
     @GetMapping
-    public ResponseEntity<List<MeteorologiaEntity>> buscarTodosRegistros() {
-        return ResponseEntity.ok(meteorologiaService.listarTudo());
+    public ResponseEntity<Page<MeteorologiaDTOLista>> buscarRegistros(Pageable paginacao) {
+        return ResponseEntity.ok(meteorologiaService.listarRegistros(paginacao));
     }
 
     @PostMapping
+    @Transactional
     public ResponseEntity<MeteorologiaEntity> criarRegistro(@RequestBody MeteorologiaEntity meteorologia) {
         return new ResponseEntity<>(meteorologiaService.novoRegistro(meteorologia), HttpStatus.CREATED);
     }

--- a/src/main/java/com/template/presentation/controller/MeteorologiaController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologiaController.java
@@ -6,6 +6,8 @@ import com.template.data.entity.MeteorologiaEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +22,8 @@ public class MeteorologiaController {
     MeteorologiaService meteorologiaService;
 
     @GetMapping
-    public ResponseEntity<Page<MeteorologiaDTOLista>> buscarRegistros(Pageable paginacao) {
+    public ResponseEntity<Page<MeteorologiaDTOLista>> buscarRegistros(
+            @PageableDefault(sort = {"data"}, direction = Sort.Direction.DESC) Pageable paginacao) {
         return ResponseEntity.ok(meteorologiaService.listarRegistros(paginacao));
     }
 

--- a/src/main/java/com/template/presentation/controller/MeteorologiaController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologiaController.java
@@ -43,6 +43,7 @@ public class MeteorologiaController {
     }
 
     @DeleteMapping("/{id}")
+    @Transactional
     public ResponseEntity<MeteorologiaEntity> excluirRegistro(@PathVariable long id) {
         try {
             meteorologiaService.excluirRegistro(id);

--- a/src/main/resources/db/migration/V5__create_meteorologia_table.sql
+++ b/src/main/resources/db/migration/V5__create_meteorologia_table.sql
@@ -1,0 +1,17 @@
+--create table IF NOT EXISTS meteorologia (
+--
+--    id bigint not null,
+--    cidade varchar(255) not null,
+--    data date not null,
+--    tempo ENUM('SOL', 'SOL_COM_NUVENS', 'NUBLADO', 'CHUVA', 'TEMPESTADE') not null,
+--    turno ENUM('DIA', 'NOITE') not null,
+--    temperaturaMaxima float not null,
+--    temperaturaMinima float not null,
+--    precipitacao float not null,
+--    umidade float not null,
+--    ventos float not null,
+--
+--    primary key (id)
+--);
+--
+--create sequence meteorologia_seq start with 1 increment by 17

--- a/src/test/java/com/template/service/MeteorologiaServiceTest.java
+++ b/src/test/java/com/template/service/MeteorologiaServiceTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,22 +46,22 @@ public class MeteorologiaServiceTest {
         );
     }
 
-    @Test
-    void buscarTodosOsRegistrosComSucesso() {
-        MeteorologiaEntity dummyMeteorologia = novaMeteorologia();
-        MeteorologiaEntity dummyMeteorologia1 = outraMeteorologia();
-
-        when(meteorologiaRepositoryMock.findAll()).thenReturn(List.of(dummyMeteorologia, dummyMeteorologia1));
-
-        List<MeteorologiaEntity> lista = meteorologiaService.listarTudo();
-
-        assertNotNull(lista);
-        assertEquals(2, lista.size());
-        assertEquals(MeteorologiaEntity.class, lista.get(0).getClass());
-
-        assertEquals(dummyMeteorologia, lista.get(0));
-        assertEquals(dummyMeteorologia1, lista.get(1));
-    }
+//    @Test
+//    void buscarTodosOsRegistrosComSucesso() {
+//        MeteorologiaEntity dummyMeteorologia = novaMeteorologia();
+//        MeteorologiaEntity dummyMeteorologia1 = outraMeteorologia();
+//
+//        when(meteorologiaRepositoryMock.findAll()).thenReturn(List.of(dummyMeteorologia, dummyMeteorologia1));
+//
+//        Page<MeteorologiaEntity> lista = meteorologiaService.listarTudo();
+//
+//        assertNotNull(lista);
+//        assertEquals(2, lista.size());
+//        assertEquals(MeteorologiaEntity.class, lista.get(0).getClass());
+//
+//        assertEquals(dummyMeteorologia, lista.get(0));
+//        assertEquals(dummyMeteorologia1, lista.get(1));
+//    }
 
     @Test
     void registrarMeteorologiaComSucesso() {

--- a/src/test/java/com/template/service/MeteorologiaServiceTest.java
+++ b/src/test/java/com/template/service/MeteorologiaServiceTest.java
@@ -1,27 +1,29 @@
 package com.template.service;
 
 import com.template.business.services.MeteorologiaService;
+import com.template.data.DTOs.MeteorologiaDTOLista;
 import com.template.data.entity.MeteorologiaEntity;
 import com.template.data.enumKind.Tempo;
 import com.template.data.enumKind.Turno;
 import com.template.data.repository.MeteorologiaRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,22 +48,24 @@ public class MeteorologiaServiceTest {
         );
     }
 
-//    @Test
-//    void buscarTodosOsRegistrosComSucesso() {
-//        MeteorologiaEntity dummyMeteorologia = novaMeteorologia();
-//        MeteorologiaEntity dummyMeteorologia1 = outraMeteorologia();
-//
-//        when(meteorologiaRepositoryMock.findAll()).thenReturn(List.of(dummyMeteorologia, dummyMeteorologia1));
-//
-//        Page<MeteorologiaEntity> lista = meteorologiaService.listarTudo();
-//
-//        assertNotNull(lista);
-//        assertEquals(2, lista.size());
-//        assertEquals(MeteorologiaEntity.class, lista.get(0).getClass());
-//
-//        assertEquals(dummyMeteorologia, lista.get(0));
-//        assertEquals(dummyMeteorologia1, lista.get(1));
-//    }
+    @Test
+    void buscarPaginaDeRegistrosComSucesso() {
+        MeteorologiaEntity item01 = novaMeteorologia();
+        MeteorologiaEntity item02 = outraMeteorologia();
+        MeteorologiaEntity item03 = new MeteorologiaEntity();
+
+        Pageable paginacao = PageRequest.of(0,10);
+        List<MeteorologiaEntity> listaMeteorologias = List.of(item01, item02, item03);
+        Page<MeteorologiaEntity> pagina = new PageImpl<>(listaMeteorologias, paginacao, 1);
+
+        when(meteorologiaRepositoryMock.findAll(paginacao)).thenReturn(pagina);
+
+        Page<MeteorologiaDTOLista> paginaMeteorologias = meteorologiaService.listarRegistros(paginacao);
+
+        Assertions.assertNotNull(listaMeteorologias);
+        Assertions.assertNotNull(paginaMeteorologias);
+        Assertions.assertEquals(3, paginaMeteorologias.getTotalElements());
+    }
 
     @Test
     void registrarMeteorologiaComSucesso() {
@@ -79,7 +83,7 @@ public class MeteorologiaServiceTest {
         try {
             meteorologiaRepositoryMock.save(meteorologiaSemData);
         } catch (Exception e) {
-            assertEquals(RuntimeException.class, e.getClass());
+            Assertions.assertEquals(RuntimeException.class, e.getClass());
         }
     }
 }

--- a/src/test/java/com/template/service/MeteorologiaServiceTest.java
+++ b/src/test/java/com/template/service/MeteorologiaServiceTest.java
@@ -68,6 +68,23 @@ public class MeteorologiaServiceTest {
     }
 
     @Test
+    void buscarTodosOsRegistrosComSucesso() {
+        MeteorologiaEntity dummyMeteorologia = novaMeteorologia();
+        MeteorologiaEntity dummyMeteorologia1 = outraMeteorologia();
+
+        when(meteorologiaRepositoryMock.findAll()).thenReturn(List.of(dummyMeteorologia, dummyMeteorologia1));
+
+        List<MeteorologiaEntity> lista = meteorologiaService.listarTudo();
+
+        Assertions.assertNotNull(lista);
+        Assertions.assertEquals(2, lista.size());
+        Assertions.assertEquals(MeteorologiaEntity.class, lista.get(0).getClass());
+
+        Assertions.assertEquals(dummyMeteorologia, lista.get(0));
+        Assertions.assertEquals(dummyMeteorologia1, lista.get(1));
+    }
+
+    @Test
     void registrarMeteorologiaComSucesso() {
         MeteorologiaEntity dummyMeteorologia = novaMeteorologia();
         when(meteorologiaRepositoryMock.save(dummyMeteorologia)).thenReturn(dummyMeteorologia);


### PR DESCRIPTION
Este pull request tem como principal objetivo refatorar o método findAll.

Antes: trazia todos os registros meteorológicos com todos os seus atributos e ordenados de forma crescente segundo o número do ID com o qual foram registrados.

Agora: traz 10 registros meteorológicos por página contendo apenas o nome da cidade e a data do registro ao qual ele se refere, ordenados por ordem decrescente segundo esta mesma data.

Este método é usado apenas para listar os registros na página de listas enquanto o nome de uma cidade não é pesquisada. Poderá sofrer novas refatorações futuramente para trazer mais dados e de forma mais dinâmica, por exemplo.

O teste unitário do service relativo a este método em específico foi refeito levando em consideração a classe Page. Todos os testes unitários do service permanecem passando com 100% de cobertura e incluem ambos cenários de sucesso e de falha.

Os testes de controller não serão feitos de forma unitária e, sim, como testes de integração posteriormente.