### PR TITLE
Feature: Recuperar registro meteorológico por ID

### DIFF
--- a/src/main/java/com/template/business/services/MeteorologiaService.java
+++ b/src/main/java/com/template/business/services/MeteorologiaService.java
@@ -40,6 +40,16 @@ public class MeteorologiaService {
         return meteorologiaRepository.findAll();
     }
 
+    public Optional<MeteorologiaEntity> buscarPorId(long id) {
+        Optional<MeteorologiaEntity> busca = meteorologiaRepository.findById(id);
+
+        if (busca.isEmpty()) {
+            throw new MeteorologiaNotFoundException("Registro não encontrado.");
+        } else {
+            return busca;
+        }
+    }
+
     public Page<MeteorologiaDTODadosLista> listarPorCidade(Pageable paginacao, String cidade) {
         Page<MeteorologiaDTODadosLista> buscar = meteorologiaRepository.findByCidade(paginacao, cidade)
                 .map(MeteorologiaDTODadosLista::new);

--- a/src/main/java/com/template/presentation/controller/MeteorologiaController.java
+++ b/src/main/java/com/template/presentation/controller/MeteorologiaController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @CrossOrigin(origins = "http://localhost:4767")
 @RestController
@@ -34,6 +35,11 @@ public class MeteorologiaController {
     @GetMapping("/all")
     public ResponseEntity<List<MeteorologiaEntity>> buscarTudo() {
         return ResponseEntity.ok(meteorologiaService.listarTudo());
+    }
+
+    @GetMapping("/recuperar/{id}")
+    public ResponseEntity<Optional<MeteorologiaEntity>> buscarPorId(@PathVariable long id) {
+        return ResponseEntity.ok(meteorologiaService.buscarPorId(id));
     }
 
     @GetMapping("/{cidade}")

--- a/src/test/java/com/template/service/MeteorologiaServiceTest.java
+++ b/src/test/java/com/template/service/MeteorologiaServiceTest.java
@@ -117,6 +117,29 @@ public class MeteorologiaServiceTest {
     }
 
     @Test
+    void buscarRegistroPorIdComSucesso() {
+        MeteorologiaEntity registro1 = novaMeteorologia();
+
+        when(meteorologiaRepositoryMock.findById(registro1.getId())).thenReturn(Optional.of(registro1));
+
+        Optional<MeteorologiaEntity> respostaDoMetodo = meteorologiaService.buscarPorId(registro1.getId());
+
+        Assertions.assertNotNull(respostaDoMetodo);
+        Assertions.assertEquals(registro1, respostaDoMetodo.get());
+
+        verify(meteorologiaRepositoryMock).findById(registro1.getId());
+    }
+
+    @Test
+    void buscarRegistroInexistentePorIdEFalhar() {
+        when(meteorologiaRepositoryMock.findById(anyLong())).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(MeteorologiaNotFoundException.class,
+                () -> meteorologiaService.buscarPorId(anyLong()));
+        verify(meteorologiaRepositoryMock).findById(anyLong());
+    }
+
+    @Test
     void buscarPorCidadeComSucesso() {
         MeteorologiaEntity cidade1 = novaMeteorologia();
         MeteorologiaEntity maisUmRegistroCidade1 = new MeteorologiaEntity(1234L, "Cidade1",


### PR DESCRIPTION
O principal objetivo deste pull request é implementar a possibilidade de recuperar os dados completos de um registro meteorológico através de seu ID. Para isso, os principais pontos de desenvolvimento foram:
1. O método buscarPorId() no service, que recupera o método findById do JPA, adicionando uma camada de verificação: lança uma exceção NotFound caso o ID não exista e retorna o objeto caso o encontre;
2. A requisição GET buscarPorId() no controller, que tem como parâmetro fixo "/recuperar" e parâmetro dinâmico o ID do registro. O parâmetro fixo foi implementado porque o uso direto do @PathVariable ID conflitava com outra requisição GET e a palavra "recuperar" foi escolhida porque a intenção do método é recuperar os dados anteriores do registro para exibi-los no front-end no momento imediatamente anterior ao início da edição pelo usuário (ou seja, a primeira coisa que ele verá logo após clicar no ícone de edição).
3. Testes unitários da classe service: 1 cenário de sucesso e 1 cenário de falha, ambos passando com 100% de cobertura do código.

O controller não foi testado de forma unitária pois será testado posteriormente de forma integrada.